### PR TITLE
Remove AchievementEngineConf.configure_classes.

### DIFF
--- a/achievements/models.py
+++ b/achievements/models.py
@@ -76,9 +76,6 @@ class AchievementEngineConf(AppConf):
     class Meta:
         prefix = 'achievement'
 
-    def configure_classes(self, value):
-        pass
-
 # connect to the end of the syncdb command signal to reload achievements at that time.
 if 'south' in settings.INSTALLED_APPS:
     from south.signals import post_migrate


### PR DESCRIPTION
If this method is empty it sets settings.ACHIEVMENTS_CLASSES to
None. This is wierd and makes harder to reuse that settings,
so I'm symplyfiing this.
